### PR TITLE
fix: fix typo in `index.json`, add `| safeURL` for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the `layouts` folder, create an `index.json` file.
   {{- range where .Site.RegularPages "Section" "ne" "" -}}
      {{- if not .Params.noSearch -}}
         {{- if gt $i 0 }},{{ end -}}
-        {"title":{{ .Title | jsonify }},"body": {{ .Plain | htmlUnescape | chomp | jsonify }},"uri":"{{ .RelPermalink }}","meta":{"date": "{{ .Date.Format "2006-01-02" }}","synonyms": {{ .Params.Synonyms | jsonify }},"specialites": {{ .Params.specialites | jsonify }},"annees": "{{ .Params.annees }}","sources": {{ .Params.sources | jsonify }},"tags": [{{- $t := 0 }}{{- range .Param "tags" -}}{{ if gt $t 0 }},{{ end }}{{ . | jsonify }}{{ $t = add $t 1 }}{{ end -}}]}}
+        {"title":{{ .Title | jsonify }},"body": {{ .Plain | htmlUnescape | chomp | jsonify }},"url":"{{ .RelPermalink }}","meta":{"date": "{{ .Date.Format "2006-01-02" }}","synonyms": {{ .Params.Synonyms | jsonify }},"specialites": {{ .Params.specialites | jsonify }},"annees": "{{ .Params.annees }}","sources": {{ .Params.sources | jsonify }},"tags": [{{- $t := 0 }}{{- range .Param "tags" -}}{{ if gt $t 0 }},{{ end }}{{ . | jsonify }}{{ $t = add $t 1 }}{{ end -}}]}}
         {{- $i = add $i 1 -}}
      {{- end -}}
   {{- end -}} ]

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -2,7 +2,7 @@
   {{- range where .Site.RegularPages "Section" "ne" "" -}}
      {{- if not .Params.noSearch -}}
         {{- if gt $i 0 }},{{ end -}}
-        {"title":{{ .Title | jsonify }},"body": {{ .Content | plainify | htmlUnescape | chomp | jsonify }},"uri":"{{ .RelPermalink }}","meta":{"date": "{{ .Date.Format "2006-01-02" }}","synonyms": {{ .Params.Synonyms | jsonify }},"specialites": {{ .Params.specialites | jsonify }},"annees": "{{ .Params.annees }}","sources": {{ .Params.sources | jsonify }},"tags": [{{- $t := 0 }}{{- range .Param "tags" -}}{{ if gt $t 0 }},{{ end }}{{ . | jsonify }}{{ $t = add $t 1 }}{{ end -}}]}}
+        {"title":{{ .Title | jsonify }},"body": {{ .Content | plainify | htmlUnescape | chomp | jsonify }},"url":"{{ .RelPermalink | safeURL }}","meta":{"date": "{{ .Date.Format "2006-01-02" }}","synonyms": {{ .Params.Synonyms | jsonify }},"specialites": {{ .Params.specialites | jsonify }},"annees": "{{ .Params.annees }}","sources": {{ .Params.sources | jsonify }},"tags": [{{- $t := 0 }}{{- range .Param "tags" -}}{{ if gt $t 0 }},{{ end }}{{ . | jsonify }}{{ $t = add $t 1 }}{{ end -}}]}}
         {{- $i = add $i 1 -}}
      {{- end -}}
   {{- end -}} ]


### PR DESCRIPTION
## What's wrong?

The script in `index.html` has the `url` in scema. But in the Hugo template (`index.json`), it's `uri`. Thus the search doesn't work.

1) index.html :
https://github.com/djibe/hugo-lyra-search/blob/27240b97a0638f24dd6828363c089a71c89cc5ae/layouts/index.html#L29-L33

2) index.json : 
https://github.com/djibe/hugo-lyra-search/blob/27240b97a0638f24dd6828363c089a71c89cc5ae/layouts/index.json#L5

## Fix
Change `uri` to `url` (as defined in JS)

Additionally, I have piped the URL to Hugo [`safeURL`](https://gohugo.io/functions/safeurl/) function.